### PR TITLE
update hadoop remote url

### DIFF
--- a/apache/docker/sentry/Dockerfile
+++ b/apache/docker/sentry/Dockerfile
@@ -9,7 +9,7 @@ ARG HADOOP_VERSION=2.7.5
 
 WORKDIR /opt
 ADD http://repo1.maven.org/maven2/org/apache/sentry/sentry-dist/${SENTRY_VERSION}/sentry-dist-${SENTRY_VERSION}-bin.tar.gz /opt
-ADD http://ftp.heanet.ie/mirrors/www.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz /opt
+ADD ADD https://archive.apache.org/dist/hadoop/core/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz /opt
 
 RUN tar zxvf sentry-dist-${SENTRY_VERSION}-bin.tar.gz \
  && tar zxvf hadoop-${HADOOP_VERSION}.tar.gz \


### PR DESCRIPTION
since the hadoop==2.7.5 was not in the mirror site, replace it with the archive path.